### PR TITLE
Bugfix: meta_train_dataset etc. are attributes of benchmark

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,9 +90,9 @@ def main(args):
             with open(args.model_path, 'wb') as f:
                 torch.save(benchmark.model.state_dict(), f)
 
-    if hasattr(meta_train_dataset, 'close'):
-        meta_train_dataset.close()
-        meta_val_dataset.close()
+    if hasattr(benchmark.meta_train_dataset, 'close'):
+        benchmark.meta_train_dataset.close()
+        benchmark.meta_val_dataset.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since meta_train_dataset etc. are attributes of benachmark, accessing meta_train_dataset results in a error. 