### PR TITLE
Batchnorm track running state

### DIFF
--- a/maml/model.py
+++ b/maml/model.py
@@ -9,7 +9,7 @@ def conv_block(in_channels, out_channels, **kwargs):
     return MetaSequential(OrderedDict([
         ('conv', MetaConv2d(in_channels, out_channels, **kwargs)),
         ('norm', nn.BatchNorm2d(out_channels, momentum=1.,
-            track_running_stats=False)),
+            track_running_stats=True)),
         ('relu', nn.ReLU()),
         ('pool', nn.MaxPool2d(2))
     ]))

--- a/maml/tests/test_batchsize.py
+++ b/maml/tests/test_batchsize.py
@@ -1,0 +1,49 @@
+import pytest
+from maml.datasets import get_benchmark_by_name
+from maml.metalearners import ModelAgnosticMetaLearning
+from maml.utils import tensors_to_device
+from torchmeta.utils.data import BatchMetaDataLoader
+import torch
+
+def test_batchsize():
+    num_steps = 1
+    num_workers = 0
+    dataset = 'miniimagenet'
+    folder = 'data/miniimagenet'
+    num_ways = 4
+    num_shots = 4
+    num_shots_test = 4
+    hidden_size = 64
+    batch_size = 5
+    first_order = False
+    step_size = 0.1
+    benchmark = get_benchmark_by_name(dataset,
+                                      folder,
+                                      num_ways,
+                                      num_shots,
+                                      num_shots_test,
+                                      hidden_size=hidden_size)
+    meta_test_dataloader = BatchMetaDataLoader(benchmark.meta_test_dataset,
+                                               batch_size=batch_size,
+                                               shuffle=True,
+                                               num_workers=num_workers,
+                                               pin_memory=True)
+    metalearner = ModelAgnosticMetaLearning(benchmark.model,
+                                            first_order=first_order,
+                                            num_adaptation_steps=num_steps,
+                                            step_size=step_size,
+                                            loss_function=benchmark.loss_function,
+                                            device='cpu')
+    for batch in meta_test_dataloader:
+        batch = tensors_to_device(batch, device='cpu')
+        for task_id, (train_inputs, train_targets, test_inputs, test_targets) in enumerate(zip(*batch['train'], *batch['test'])):
+            params, _ = metalearner.adapt(train_inputs, train_targets,
+                                                    is_classification_task=True,
+                                                    num_adaptation_steps=metalearner.num_adaptation_steps,
+                                                    step_size=metalearner.step_size, first_order=metalearner.first_order)
+            test_logits_1 = metalearner.model(test_inputs, params=params)
+            for idx in range(test_inputs.shape[0]):
+                test_logits_2 = metalearner.model(test_inputs[idx:idx + 1, ...], params=params)
+                assert torch.allclose(test_logits_1[idx:idx + 1, ...], test_logits_2, atol=1e-04)
+        break
+    return

--- a/maml/tests/test_batchsize.py
+++ b/maml/tests/test_batchsize.py
@@ -37,10 +37,12 @@ def test_batchsize():
     for batch in meta_test_dataloader:
         batch = tensors_to_device(batch, device='cpu')
         for task_id, (train_inputs, train_targets, test_inputs, test_targets) in enumerate(zip(*batch['train'], *batch['test'])):
+            metalearner.model.train(True)
             params, _ = metalearner.adapt(train_inputs, train_targets,
                                                     is_classification_task=True,
                                                     num_adaptation_steps=metalearner.num_adaptation_steps,
                                                     step_size=metalearner.step_size, first_order=metalearner.first_order)
+            metalearner.model.train(False)
             test_logits_1 = metalearner.model(test_inputs, params=params)
             for idx in range(test_inputs.shape[0]):
                 test_logits_2 = metalearner.model(test_inputs[idx:idx + 1, ...], params=params)

--- a/train.py
+++ b/train.py
@@ -65,11 +65,13 @@ def main(args):
     # Training loop
     epoch_desc = 'Epoch {{0: <{0}d}}'.format(1 + int(math.log10(args.num_epochs)))
     for epoch in range(args.num_epochs):
+        metalearner.training = True
         metalearner.train(meta_train_dataloader,
                           max_batches=args.num_batches,
                           verbose=args.verbose,
                           desc='Training',
                           leave=False)
+        metalearner.training = False
         results = metalearner.evaluate(meta_val_dataloader,
                                        max_batches=args.num_batches,
                                        verbose=args.verbose,


### PR DESCRIPTION
I found out that during inference a larger batch size results in better results than a smaller one. To avoid this the batchnorm layer needs to track the running state.